### PR TITLE
Update carbon dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.2",
         "ext-json": "*",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "php-http/client-common": "^2.4",
         "php-http/discovery": "^1.15.0",
-        "nesbot/carbon": "^2.67"
+        "nesbot/carbon": "^3.8"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.4",


### PR DESCRIPTION
The version of nesbot/carbon that is currently used is not compatible with the latest Symfony version.

This PR updates the package to the latest 3.8 version.

Note: the minimum PHP version of this new package version is 8.1.

I don't think this should be a problem since 8.0 and older is not supported anymore: https://www.php.net/supported-versions.php